### PR TITLE
Fix burner connector raw transaction

### DIFF
--- a/.changeset/beige-paws-count.md
+++ b/.changeset/beige-paws-count.md
@@ -1,0 +1,5 @@
+---
+"burner-connector": patch
+---
+
+fix: format transaction properties before sending

--- a/packages/burner-connector/src/burnerConnector/burner.ts
+++ b/packages/burner-connector/src/burnerConnector/burner.ts
@@ -11,7 +11,7 @@ import {
   getAddress,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { getHttpRpcClient, hexToBigInt, numberToHex } from "viem/utils";
+import { getHttpRpcClient, hexToBigInt, hexToNumber, numberToHex } from "viem/utils";
 import { burnerWalletId, burnerWalletName, loadBurnerPK } from "../utils/index.js";
 
 export class ConnectorNotConnectedError extends BaseError {
@@ -65,10 +65,22 @@ export const burner = () => {
       const request: EIP1193RequestFn = async ({ method, params }) => {
         if (method === "eth_sendTransaction") {
           const actualParams = (params as SendTransactionParameters[])[0];
-          const value = actualParams?.value ? hexToBigInt(actualParams.value as unknown as Hex) : undefined;
           const hash = await client.sendTransaction({
-            ...(params as SendTransactionParameters[])[0],
-            value,
+            account: burnerAccount,
+            data: actualParams?.data,
+            to: actualParams?.to,
+            value: actualParams?.value ? hexToBigInt(actualParams.value as unknown as Hex) : undefined,
+            gas: actualParams?.gas ? hexToBigInt(actualParams.gas as unknown as Hex) : undefined,
+            nonce: actualParams?.nonce ? hexToNumber(actualParams.nonce as unknown as Hex) : undefined,
+            maxPriorityFeePerGas: actualParams?.maxPriorityFeePerGas
+              ? hexToBigInt(actualParams.maxPriorityFeePerGas as unknown as Hex)
+              : undefined,
+            maxFeePerGas: actualParams?.maxFeePerGas
+              ? hexToBigInt(actualParams.maxFeePerGas as unknown as Hex)
+              : undefined,
+            gasPrice: (actualParams?.gasPrice
+              ? hexToBigInt(actualParams.gasPrice as unknown as Hex)
+              : undefined) as undefined,
           });
           return hash;
         }


### PR DESCRIPTION
### Description : 

Sending transaction with `useSendTranscation` were failing, because we were passing hex gas values to viems's [sendTransaction write actions ](https://viem.sh/docs/actions/wallet/sendTransaction#sendtransaction) instead it accepts bigInt 

Also did some digging why `useSendTransaction` was not working and `useTransactor` was working was because when you use `sendTransaction` from wagmi hook it passes some gas value, and when you do `walletClient.sendTransaction` (we are doing this in `useWalletClient`) this sends gas value as 0 

![Screenshot 2024-05-15 at 5 30 44 PM](https://github.com/scaffold-eth/burner-connector/assets/80153681/368781f7-086b-4dbc-b771-2ecb92467c40)


Solution, found this [file in viem](https://github.com/wevm/viem/blob/0bfdfcfa2d8f5fcd0f67eb2dcb00019f37bc7c32/src/utils/formatters/transactionRequest.ts#L46) reversed engineered it and passed all the options accepted by viem's [sendTransaction](https://viem.sh/docs/actions/wallet/sendTransaction#sendtransaction). 

Didn't handled advanced options like `kzg` and `blobs` we can maybe find better / other way in future PR's 

