### PR TITLE
feat: allow custom rpc urls

### DIFF
--- a/.changeset/sixty-pans-visit.md
+++ b/.changeset/sixty-pans-visit.md
@@ -1,0 +1,5 @@
+---
+"burner-connector": patch
+---
+
+feat: allow custom rpc urls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 9.0.6
+          version: 9.14.2
 
       - name: Setup node env
         uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -24,19 +24,39 @@ or
 pnpm add burner-connector
 ```
 
-2. Using wagmi `burner` connector :
+2. Using wagmi `burner` connector:
 
 ```ts
 import { burner } from "burner-connector";
 import { mainnet, base } from "viem/chains";
 
-// burner function can also called with param `{ useSessionStorage: true }` to create a new wallet for each browser tab
-// - `useSessionStorage` to false (default) to persist wallet across browser tabs(incognito window will have different wallet)
-// - `useSessionStorage` to true to create a new wallet for each browser tab
+// Configuration options:
+// - `useSessionStorage`: false (default) to persist wallet across browser tabs
+//                       true to create a new wallet for each browser tab
+// - `rpcUrls`: Optional custom RPC URLs for specific chain IDs
 
+// Basic usage without options
 export const config = createConfig({
   chains: [mainnet, base],
   connectors: [burner()],
+  transports: {
+    [mainnet.id]: http(),
+    [base.id]: http(),
+  },
+});
+
+// Example with all options
+export const config = createConfig({
+  chains: [mainnet, base],
+  connectors: [
+    burner({
+      useSessionStorage: true,
+      rpcUrls: {
+        1: "https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+        8453: "https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+      },
+    }),
+  ],
   transports: {
     [mainnet.id]: http(),
     [base.id]: http(),
@@ -52,12 +72,17 @@ import { metaMaskWallet } from "@rainbow-me/rainbowkit/wallets";
 import { rainbowkitBurnerWallet } from "burner-connector";
 import { mainnet, base } from "viem/chains";
 
-const wallets = [metaMaskWallet, rainbowkitBurnerWallet];
+// Configure burner wallet options
+// Storage configuration:
+// - useSessionStorage: false (default) to persist wallet across browser tabs
+//                     true to create a new wallet for each browser tab
+rainbowkitBurnerWallet.useSessionStorage = true;
 
-// Configure burner wallet storage
-// - `useSessionStorage` to false (default) to persist wallet across browser tabs(incognito window will have different wallet)
-// - `useSessionStorage` to true to create a new wallet for each browser tab
-// rainbowkitBurnerWallet.useSessionStorage = true;
+// Custom RPC URLs configuration (optional):
+rainbowkitBurnerWallet.rpcUrls = {
+  1: "https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+  8453: "https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+};
 
 const wallets = [metaMaskWallet, rainbowkitBurnerWallet];
 
@@ -84,6 +109,15 @@ const wagmiConfig = createConfig({
   },
 });
 ```
+
+## Configuration Options
+
+### Burner Connector Options
+
+| Option              | Type                     | Default | Description                                                                                     |
+| ------------------- | ------------------------ | ------- | ----------------------------------------------------------------------------------------------- |
+| `useSessionStorage` | `boolean`                | `false` | When true, creates a new wallet for each browser tab. When false, persists wallet across tabs.  |
+| `rpcUrls`           | `Record<number, string>` | `{}`    | Optional custom RPC URLs for specific chain IDs. Falls back to chain's default if not provided. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ import { burner } from "burner-connector";
 import { mainnet, base } from "viem/chains";
 
 // Configuration options:
-// - `useSessionStorage`: false (default) to persist wallet across browser tabs
+// - `useSessionStorage` (optional) : false (default) to persist wallet across browser tabs
 //                       true to create a new wallet for each browser tab
-// - `rpcUrls`: Optional custom RPC URLs for specific chain IDs
+// - `rpcUrls` (optional) : custom RPC URLs for specific chain IDs
 
 // Basic usage without options
 export const config = createConfig({
@@ -114,10 +114,10 @@ const wagmiConfig = createConfig({
 
 ### Burner Connector Options
 
-| Option              | Type                     | Default | Description                                                                                     |
-| ------------------- | ------------------------ | ------- | ----------------------------------------------------------------------------------------------- |
-| `useSessionStorage` | `boolean`                | `false` | When true, creates a new wallet for each browser tab. When false, persists wallet across tabs.  |
-| `rpcUrls`           | `Record<number, string>` | `{}`    | Optional custom RPC URLs for specific chain IDs. Falls back to chain's default if not provided. |
+| Option                         | Type                     | Default     | Description                                                                                     |
+| ------------------------------ | ------------------------ | ----------- | ----------------------------------------------------------------------------------------------- |
+| `useSessionStorage` (optional) | `boolean`                | `false`     | When true, creates a new wallet for each browser tab. When false, persists wallet across tabs.  |
+| `rpcUrls` (optional)           | `Record<number, string>` | `undefined` | Optional custom RPC URLs for specific chain IDs. Falls back to chain's default if not provided. |
 
 ---
 

--- a/example/app/wagmiConfig.ts
+++ b/example/app/wagmiConfig.ts
@@ -8,6 +8,11 @@ import { rainbowkitBurnerWallet } from "burner-connector";
 // Use this if you want to enable session storage
 // rainbowkitBurnerWallet.useSessionStorage = true;
 
+/* Use custom RPC URLs to override wagmi's default RPC URLs if needed */
+/* rainbowkitBurnerWallet.rpcUrls = {
+  [optimismSepolia.id]: `https://opt-sepolia.g.alchemy.com/v2/${alchemyAPIKey}`,
+}; */
+
 const wallets = [metaMaskWallet, rainbowkitBurnerWallet];
 const walletConnectProjectID = "3a8170812b534d0ff9d794f19a901d64";
 const wagmiConnectors = connectorsForWallets(
@@ -21,7 +26,7 @@ const wagmiConnectors = connectorsForWallets(
   {
     appName: "scaffold-eth-2",
     projectId: walletConnectProjectID,
-  }
+  },
 );
 
 export const chains = [optimismSepolia, hardhat] as const;

--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
   "license": "MIT",
   "devDependencies": {
     "@changesets/cli": "^2.27.1"
-  }
+  },
+  "packageManager": "pnpm@9.14.2+sha512.6e2baf77d06b9362294152c851c4f278ede37ab1eba3a55fda317a4a17b209f4dbb973fb250a77abc463a341fcb1f17f17cfa24091c4eb319cda0d9b84278387"
 }

--- a/packages/burner-connector/README.md
+++ b/packages/burner-connector/README.md
@@ -1,5 +1,13 @@
 # 🔥 Burner Connector
 
+## Requirements
+
+Before you begin, you need to install the following tools:
+
+- [Node (>= v18.17)](https://nodejs.org/en/download/)
+- [pnpm](https://pnpm.io/installation#using-corepack)
+- [Git](https://git-scm.com/downloads)
+
 ## Quickstart
 
 1. Install the dependencies:
@@ -21,6 +29,11 @@ pnpm add burner-connector
 ```ts
 import { burner } from "burner-connector";
 import { mainnet, base } from "viem/chains";
+
+// burner function can also called with param `{ useSessionStorage: true }` to create a new wallet for each browser tab
+// - `useSessionStorage` to false (default) to persist wallet across browser tabs(incognito window will have different wallet)
+// - `useSessionStorage` to true to create a new wallet for each browser tab
+
 export const config = createConfig({
   chains: [mainnet, base],
   connectors: [burner()],
@@ -38,6 +51,13 @@ import { connectorsForWallets } from "@rainbow-me/rainbowkit";
 import { metaMaskWallet } from "@rainbow-me/rainbowkit/wallets";
 import { rainbowkitBurnerWallet } from "burner-connector";
 import { mainnet, base } from "viem/chains";
+
+const wallets = [metaMaskWallet, rainbowkitBurnerWallet];
+
+// Configure burner wallet storage
+// - `useSessionStorage` to false (default) to persist wallet across browser tabs(incognito window will have different wallet)
+// - `useSessionStorage` to true to create a new wallet for each browser tab
+// rainbowkitBurnerWallet.useSessionStorage = true;
 
 const wallets = [metaMaskWallet, rainbowkitBurnerWallet];
 
@@ -64,3 +84,7 @@ const wagmiConfig = createConfig({
   },
 });
 ```
+
+---
+
+Checkout [CONTRIBUTING.md](/CONTRIBUTING.md) for more details on how to set it up locally.

--- a/packages/burner-connector/README.md
+++ b/packages/burner-connector/README.md
@@ -23,9 +23,9 @@ import { burner } from "burner-connector";
 import { mainnet, base } from "viem/chains";
 
 // Configuration options:
-// - `useSessionStorage`: false (default) to persist wallet across browser tabs
+// - `useSessionStorage` (optional) : false (default) to persist wallet across browser tabs
 //                       true to create a new wallet for each browser tab
-// - `rpcUrls`: Optional custom RPC URLs for specific chain IDs
+// - `rpcUrls` (optional) : custom RPC URLs for specific chain IDs
 
 // Basic usage without options
 export const config = createConfig({
@@ -106,10 +106,10 @@ const wagmiConfig = createConfig({
 
 ### Burner Connector Options
 
-| Option              | Type                     | Default | Description                                                                                     |
-| ------------------- | ------------------------ | ------- | ----------------------------------------------------------------------------------------------- |
-| `useSessionStorage` | `boolean`                | `false` | When true, creates a new wallet for each browser tab. When false, persists wallet across tabs.  |
-| `rpcUrls`           | `Record<number, string>` | `{}`    | Optional custom RPC URLs for specific chain IDs. Falls back to chain's default if not provided. |
+| Option                         | Type                     | Default     | Description                                                                                     |
+| ------------------------------ | ------------------------ | ----------- | ----------------------------------------------------------------------------------------------- |
+| `useSessionStorage` (optional) | `boolean`                | `false`     | When true, creates a new wallet for each browser tab. When false, persists wallet across tabs.  |
+| `rpcUrls` (optional)           | `Record<number, string>` | `undefined` | Optional custom RPC URLs for specific chain IDs. Falls back to chain's default if not provided. |
 
 ---
 

--- a/packages/burner-connector/README.md
+++ b/packages/burner-connector/README.md
@@ -1,13 +1,5 @@
 # 🔥 Burner Connector
 
-## Requirements
-
-Before you begin, you need to install the following tools:
-
-- [Node (>= v18.17)](https://nodejs.org/en/download/)
-- [pnpm](https://pnpm.io/installation#using-corepack)
-- [Git](https://git-scm.com/downloads)
-
 ## Quickstart
 
 1. Install the dependencies:
@@ -24,19 +16,39 @@ or
 pnpm add burner-connector
 ```
 
-2. Using wagmi `burner` connector :
+2. Using wagmi `burner` connector:
 
 ```ts
 import { burner } from "burner-connector";
 import { mainnet, base } from "viem/chains";
 
-// burner function can also called with param `{ useSessionStorage: true }` to create a new wallet for each browser tab
-// - `useSessionStorage` to false (default) to persist wallet across browser tabs(incognito window will have different wallet)
-// - `useSessionStorage` to true to create a new wallet for each browser tab
+// Configuration options:
+// - `useSessionStorage`: false (default) to persist wallet across browser tabs
+//                       true to create a new wallet for each browser tab
+// - `rpcUrls`: Optional custom RPC URLs for specific chain IDs
 
+// Basic usage without options
 export const config = createConfig({
   chains: [mainnet, base],
   connectors: [burner()],
+  transports: {
+    [mainnet.id]: http(),
+    [base.id]: http(),
+  },
+});
+
+// Example with all options
+export const config = createConfig({
+  chains: [mainnet, base],
+  connectors: [
+    burner({
+      useSessionStorage: true,
+      rpcUrls: {
+        1: "https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+        8453: "https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+      },
+    }),
+  ],
   transports: {
     [mainnet.id]: http(),
     [base.id]: http(),
@@ -52,12 +64,17 @@ import { metaMaskWallet } from "@rainbow-me/rainbowkit/wallets";
 import { rainbowkitBurnerWallet } from "burner-connector";
 import { mainnet, base } from "viem/chains";
 
-const wallets = [metaMaskWallet, rainbowkitBurnerWallet];
+// Configure burner wallet options
+// Storage configuration:
+// - useSessionStorage: false (default) to persist wallet across browser tabs
+//                     true to create a new wallet for each browser tab
+rainbowkitBurnerWallet.useSessionStorage = true;
 
-// Configure burner wallet storage
-// - `useSessionStorage` to false (default) to persist wallet across browser tabs(incognito window will have different wallet)
-// - `useSessionStorage` to true to create a new wallet for each browser tab
-// rainbowkitBurnerWallet.useSessionStorage = true;
+// Custom RPC URLs configuration (optional):
+rainbowkitBurnerWallet.rpcUrls = {
+  1: "https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+  8453: "https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+};
 
 const wallets = [metaMaskWallet, rainbowkitBurnerWallet];
 
@@ -84,6 +101,15 @@ const wagmiConfig = createConfig({
   },
 });
 ```
+
+## Configuration Options
+
+### Burner Connector Options
+
+| Option              | Type                     | Default | Description                                                                                     |
+| ------------------- | ------------------------ | ------- | ----------------------------------------------------------------------------------------------- |
+| `useSessionStorage` | `boolean`                | `false` | When true, creates a new wallet for each browser tab. When false, persists wallet across tabs.  |
+| `rpcUrls`           | `Record<number, string>` | `{}`    | Optional custom RPC URLs for specific chain IDs. Falls back to chain's default if not provided. |
 
 ---
 

--- a/packages/burner-connector/src/burnerConnector/burner.ts
+++ b/packages/burner-connector/src/burnerConnector/burner.ts
@@ -62,7 +62,6 @@ export const burner = ({ useSessionStorage = false, rpcUrls = {} }: BurnerConfig
       const url = rpcUrls[chain.id] || chain.rpcUrls.default.http[0];
       if (!url) throw new Error("No rpc url found for chain");
 
-      console.log("using the url ", url);
       const burnerAccount = privateKeyToAccount(loadBurnerPK({ useSessionStorage }));
       const client = createWalletClient({
         chain: chain,

--- a/packages/burner-connector/src/wallets/rainbowkit/rainbowkitBurnerConnector.ts
+++ b/packages/burner-connector/src/wallets/rainbowkit/rainbowkitBurnerConnector.ts
@@ -5,16 +5,22 @@ import { burner } from "../../burnerConnector/burner.js";
 
 type Provider = ReturnType<Transport<"custom", Record<any, any>, EIP1193RequestFn<WalletRpcSchema>>>;
 
-export const rainbowkitBurnerConnector = (walletDetails: WalletDetailsParams) => {
+export const rainbowkitBurnerConnector = (
+  walletDetails: WalletDetailsParams,
+  burnerWalletConfig: { rpcUrls?: Record<number, string> },
+) => {
   return createConnector<Provider>((config) => ({
-    ...burner()(config),
+    ...burner({ rpcUrls: burnerWalletConfig?.rpcUrls })(config),
     ...walletDetails,
   }));
 };
 
-export const rainbowkitSessionStorageBurnerConnector = (walletDetails: WalletDetailsParams) => {
+export const rainbowkitSessionStorageBurnerConnector = (
+  walletDetails: WalletDetailsParams,
+  burnerWalletConfig: { rpcUrls?: Record<number, string> },
+) => {
   return createConnector<Provider>((config) => ({
-    ...burner({ useSessionStorage: true })(config),
+    ...burner({ useSessionStorage: true, rpcUrls: burnerWalletConfig?.rpcUrls })(config),
     ...walletDetails,
   }));
 };

--- a/packages/burner-connector/src/wallets/rainbowkit/rainbowkitBurnerWallet.ts
+++ b/packages/burner-connector/src/wallets/rainbowkit/rainbowkitBurnerWallet.ts
@@ -1,4 +1,4 @@
-import type { Wallet } from "@rainbow-me/rainbowkit";
+import type { Wallet, WalletDetailsParams } from "@rainbow-me/rainbowkit";
 import { burnerWalletId, burnerWalletName } from "../../utils/index.js";
 import { rainbowkitBurnerConnector, rainbowkitSessionStorageBurnerConnector } from "./rainbowkitBurnerConnector.js";
 
@@ -8,6 +8,7 @@ const burnerWalletIconBase64 =
 type RainbowkitBurnerWallet = {
   (): Wallet;
   useSessionStorage?: boolean;
+  rpcUrls?: Record<number, string>;
 };
 
 /**
@@ -18,7 +19,18 @@ export const rainbowkitBurnerWallet: RainbowkitBurnerWallet = () => ({
   name: burnerWalletName,
   iconUrl: burnerWalletIconBase64,
   iconBackground: "#ffffff",
-  createConnector: rainbowkitBurnerWallet.useSessionStorage
-    ? rainbowkitSessionStorageBurnerConnector
-    : rainbowkitBurnerConnector,
+  createConnector: (params: WalletDetailsParams) => {
+    const connector = rainbowkitBurnerWallet.useSessionStorage
+      ? rainbowkitSessionStorageBurnerConnector
+      : rainbowkitBurnerConnector;
+
+    return connector(
+      {
+        ...params,
+      },
+      {
+        rpcUrls: rainbowkitBurnerWallet.rpcUrls,
+      },
+    );
+  },
 });


### PR DESCRIPTION
## To test: 

1. Build the package:

```bash
pnpm run build
```

This builds the `burner-connector` package.

2. Uncomment the this part: 
https://github.com/scaffold-eth/burner-connector/blob/fcef3885f58ac5f72f23d50251939fd462a16533/example/app/wagmiConfig.ts#L12-L14

Add this link: https://opt-sepolia.g.alchemy.com/v2/oKxs-03sij-U_N0iOlrSsZFr29-IqbuF



2. Start the example repo:

```bash
pnpm run dev
```

This will start a local server on `http://localhost:3000` with the example app linked to local package

The burner wallet should be automatically connected to optimism sepolia network, and can interact with the [`YourContract`](https://optimism-sepolia.blockscout.com/address/0xFB30C0790128b97e3aC540E6124e512E37c47D00). 

### Demo of it making write calls via custom rpc: 


https://github.com/user-attachments/assets/96fe7f1b-92f2-46d2-ab98-3c68f7af5ddc


Fixes #26 
