### PR TITLE
Update version on publish action

### DIFF
--- a/.changeset/pink-mice-impress.md
+++ b/.changeset/pink-mice-impress.md
@@ -1,0 +1,5 @@
+---
+"burner-connector": patch
+---
+
+update version on release action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 9.0.6
+          version: 9.14.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
After merging https://github.com/scaffold-eth/burner-connector/pull/29, pusblish action failed.

![Image](https://github.com/user-attachments/assets/3f5d1a8b-cf12-4ed5-a53e-e4fda7e63a3c)

Trying to update version here.