### PR TITLE
fix: use connectedChainId when chainId is not provided

### DIFF
--- a/.changeset/brave-pugs-promise.md
+++ b/.changeset/brave-pugs-promise.md
@@ -1,0 +1,5 @@
+---
+"burner-connector": patch
+---
+
+check for connectedChain too while finding main chain in `getProvider`

--- a/packages/burner-connector/src/burnerConnector/burner.ts
+++ b/packages/burner-connector/src/burnerConnector/burner.ts
@@ -63,8 +63,8 @@ export const burner = ({ useSessionStorage = false, rpcUrls = {} }: BurnerConfig
       return { accounts, chainId: currentChainId };
     },
     async getProvider({ chainId } = {}) {
-      const chain = config.chains.find((x) => x.id === chainId) ?? config.chains[0];
-
+      const targetChainId = chainId || connectedChainId;
+      const chain = config.chains.find((x) => x.id === targetChainId) ?? config.chains[0];
       // Use custom RPC URL if provided, otherwise fallback to default
       const url = rpcUrls[chain.id] || chain.rpcUrls.default.http[0];
       if (!url) throw new Error("No rpc url found for chain");


### PR DESCRIPTION
Related to issue #28

I noticed the following when I executed a transaction on the first chain: 
![photo](https://github.com/user-attachments/assets/7b9d2142-250b-4551-ac06-ac15287b421e)

and when I executed a transaction on the second chain:
![photo2](https://github.com/user-attachments/assets/aedd71b0-49bb-480a-9817-9d906ad977c8)

The fixes I have implemented helped resolve these issues, and I would appreciate a review and tests.