### PR TITLE
fix: dependent calls break gas estimation

### DIFF
--- a/.changeset/smooth-rings-kick.md
+++ b/.changeset/smooth-rings-kick.md
@@ -1,0 +1,5 @@
+---
+"burner-connector": patch
+---
+
+5792: Make calls sequentially to enable gas estimation for dependent calls

--- a/packages/burner-connector/src/burnerConnector/burner.ts
+++ b/packages/burner-connector/src/burnerConnector/burner.ts
@@ -178,7 +178,6 @@ export const burner = ({ useSessionStorage = false, rpcUrls = {} }: BurnerConfig
 
           // Execute calls sequentially for now
           const hashes: `0x${string}`[] = [];
-          let nonceIncrement = 0;
           for (const call of sendCallsParams.calls) {
             const request = await client.prepareTransactionRequest({
               account: burnerAccount,
@@ -189,14 +188,12 @@ export const burner = ({ useSessionStorage = false, rpcUrls = {} }: BurnerConfig
             const hash = await client.sendTransaction({
               ...request,
               gas: (request.gas * GAS_MULTIPLIER) / 100n,
-              nonce: request.nonce + nonceIncrement,
             });
             hashes.push(hash);
             const receipt = await publicClient.waitForTransactionReceipt({ hash });
             if (receipt.status !== "success") {
               break;
             }
-            nonceIncrement++;
           }
 
           // Create a robust ID by concatenating transaction hashes, chain ID, and magic identifier

--- a/packages/burner-connector/src/burnerConnector/burner.ts
+++ b/packages/burner-connector/src/burnerConnector/burner.ts
@@ -192,7 +192,7 @@ export const burner = ({ useSessionStorage = false, rpcUrls = {} }: BurnerConfig
               nonce: request.nonce + nonceIncrement,
             });
             hashes.push(hash);
-            const receipt = await publicClient.getTransactionReceipt({ hash });
+            const receipt = await publicClient.waitForTransactionReceipt({ hash });
             if (receipt.status !== "success") {
               break;
             }


### PR DESCRIPTION
Currently in the case of an approve swap, the gas estimation for the swap fails - in this case we submit each transaction sequentially. This means execution is slower, but is not blocked