### PR TITLE
fix: inherit consumer transport + safer mainnet default

### DIFF
--- a/example/app/wagmiConfig.ts
+++ b/example/app/wagmiConfig.ts
@@ -2,7 +2,7 @@ import { connectorsForWallets } from "@rainbow-me/rainbowkit";
 import { createConfig } from "wagmi";
 import { hardhat, mainnet, optimismSepolia } from "viem/chains";
 import { metaMaskWallet } from "@rainbow-me/rainbowkit/wallets";
-import { createClient, fallback, http } from "viem";
+import { fallback, http } from "viem";
 import { rainbowkitBurnerWallet } from "burner-connector";
 
 // Use this if you want to enable session storage
@@ -29,6 +29,9 @@ const wagmiConnectors = connectorsForWallets(
   }
 );
 
+// SE-2's public default Alchemy key — used here to demonstrate transport inheritance.
+// The burner should inherit these transports automatically (no need to also set
+// `rainbowkitBurnerWallet.rpcUrls`).
 const ALCHEMY_KEY = "cR4WnXePioePZ5fFrnSiR";
 
 export const chains = [mainnet, optimismSepolia, hardhat] as const;
@@ -37,21 +40,13 @@ export const wagmiConfig = createConfig({
   chains: chains,
   connectors: wagmiConnectors,
   ssr: true,
-  client({ chain }) {
-    const alchemyUrl =
-      chain.id === mainnet.id
-        ? `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`
-        : chain.id === optimismSepolia.id
-          ? `https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_KEY}`
-          : undefined;
-
-    const transports = alchemyUrl
-      ? fallback([http(alchemyUrl), http("https://mainnet.rpc.buidlguidl.com"), http()])
-      : fallback([http()]);
-
-    return createClient({
-      chain,
-      transport: transports,
-    });
+  transports: {
+    [mainnet.id]: fallback([
+      http(`https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`),
+      http("https://mainnet.rpc.buidlguidl.com"),
+      http(),
+    ]),
+    [optimismSepolia.id]: fallback([http(`https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_KEY}`), http()]),
+    [hardhat.id]: http(),
   },
 });

--- a/example/app/wagmiConfig.ts
+++ b/example/app/wagmiConfig.ts
@@ -1,8 +1,8 @@
 import { connectorsForWallets } from "@rainbow-me/rainbowkit";
 import { createConfig } from "wagmi";
-import { hardhat, optimismSepolia } from "viem/chains";
+import { hardhat, mainnet, optimismSepolia } from "viem/chains";
 import { metaMaskWallet } from "@rainbow-me/rainbowkit/wallets";
-import { createClient, http } from "viem";
+import { createClient, fallback, http } from "viem";
 import { rainbowkitBurnerWallet } from "burner-connector";
 
 // Use this if you want to enable session storage
@@ -29,13 +29,29 @@ const wagmiConnectors = connectorsForWallets(
   }
 );
 
-export const chains = [optimismSepolia, hardhat] as const;
+const ALCHEMY_KEY = "cR4WnXePioePZ5fFrnSiR";
+
+export const chains = [mainnet, optimismSepolia, hardhat] as const;
 
 export const wagmiConfig = createConfig({
   chains: chains,
   connectors: wagmiConnectors,
   ssr: true,
   client({ chain }) {
-    return createClient({ chain, transport: http() });
+    const alchemyUrl =
+      chain.id === mainnet.id
+        ? `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`
+        : chain.id === optimismSepolia.id
+          ? `https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_KEY}`
+          : undefined;
+
+    const transports = alchemyUrl
+      ? fallback([http(alchemyUrl), http("https://mainnet.rpc.buidlguidl.com"), http()])
+      : fallback([http()]);
+
+    return createClient({
+      chain,
+      transport: transports,
+    });
   },
 });

--- a/packages/burner-connector/src/burnerConnector/burner.ts
+++ b/packages/burner-connector/src/burnerConnector/burner.ts
@@ -1,4 +1,4 @@
-import { createConnector, normalizeChainId, type Config } from "wagmi";
+import { createConnector, normalizeChainId } from "wagmi";
 import type {
   EIP1193RequestFn,
   Hex,
@@ -26,6 +26,14 @@ import { burnerWalletId, burnerWalletName, loadBurnerPK } from "../utils/index.j
 const GAS_MULTIPLIER = 110n; // 10% more gas
 // Magic identifier for burner wallet
 const BURNER_MAGIC_IDENTIFIER = "0x424E524E52424E52424E52424E52424E52424E52424E52424E52424E52424E52"; // "BNRNRBNRNRBNRNRBNRNRBNRNRBNRNRBNRNRBNRNRBNRNRBNRNRBNRNRNR"
+
+// Chains where viem's chain.rpcUrls.default has known CORS or rate-limit issues
+// in production. Mainnet's default is eth.merkle.io which blocks cross-origin
+// requests from Vercel / most hosts. Override here so the out-of-the-box burner
+// works on live domains.
+const SAFE_DEFAULT_RPC_BY_CHAIN: Record<number, string> = {
+  1: "https://mainnet.rpc.buidlguidl.com",
+};
 
 export class ConnectorNotConnectedError extends BaseError {
   override name = "ConnectorNotConnectedError";
@@ -75,10 +83,25 @@ export const burner = ({ useSessionStorage = false, rpcUrls = {} }: BurnerConfig
       const targetChainId = chainId || connectedChainId;
       const chain = config.chains.find((x) => x.id === targetChainId) ?? config.chains[0];
 
-      // Explicit override wins; otherwise inherit the parent wagmi config's transport
+      // Resolution order:
+      //   1. Explicit `rpcUrls` passed to the burner.
+      //   2. The consumer's `transports[chainId]` from createConfig — this preserves
+      //      fallback chains, Alchemy keys, etc. Only populated when the consumer
+      //      used the `transports: {}` form, not the `client()` factory.
+      //   3. Curated safer default for chains where viem's default is broken in prod.
+      //   4. viem's chain default (existing behavior).
       const overrideUrl = rpcUrls[chain.id];
-      const parentClient = overrideUrl ? undefined : (config as unknown as Config).getClient({ chainId: chain.id });
-      const transport: Transport = overrideUrl ? http(overrideUrl) : custom({ request: parentClient!.request });
+      const consumerTransport = !overrideUrl ? config.transports?.[chain.id] : undefined;
+      const fallbackUrl = SAFE_DEFAULT_RPC_BY_CHAIN[chain.id] ?? chain.rpcUrls.default.http[0];
+      const transport: Transport = overrideUrl
+        ? http(overrideUrl)
+        : consumerTransport
+          ? consumerTransport
+          : http(fallbackUrl);
+
+      if (!overrideUrl && !consumerTransport && !fallbackUrl) {
+        throw new Error("No rpc url found for chain");
+      }
 
       const burnerAccount = privateKeyToAccount(loadBurnerPK({ useSessionStorage }));
       const client = createWalletClient({

--- a/packages/burner-connector/src/burnerConnector/burner.ts
+++ b/packages/burner-connector/src/burnerConnector/burner.ts
@@ -1,4 +1,4 @@
-import { createConnector, normalizeChainId } from "wagmi";
+import { createConnector, normalizeChainId, type Config } from "wagmi";
 import type {
   EIP1193RequestFn,
   Hex,
@@ -10,7 +10,6 @@ import type {
 import {
   http,
   BaseError,
-  RpcRequestError,
   SwitchChainError,
   createWalletClient,
   custom,
@@ -21,7 +20,7 @@ import {
   concat,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { getHttpRpcClient, hexToBigInt, hexToNumber, numberToHex } from "viem/utils";
+import { hexToBigInt, hexToNumber, numberToHex } from "viem/utils";
 import { burnerWalletId, burnerWalletName, loadBurnerPK } from "../utils/index.js";
 
 const GAS_MULTIPLIER = 110n; // 10% more gas
@@ -75,22 +74,24 @@ export const burner = ({ useSessionStorage = false, rpcUrls = {} }: BurnerConfig
     async getProvider({ chainId } = {}) {
       const targetChainId = chainId || connectedChainId;
       const chain = config.chains.find((x) => x.id === targetChainId) ?? config.chains[0];
-      // Use custom RPC URL if provided, otherwise fallback to default
-      const url = rpcUrls[chain.id] || chain.rpcUrls.default.http[0];
-      if (!url) throw new Error("No rpc url found for chain");
+
+      // Explicit override wins; otherwise inherit the parent wagmi config's transport
+      const overrideUrl = rpcUrls[chain.id];
+      const parentClient = overrideUrl ? undefined : (config as unknown as Config).getClient({ chainId: chain.id });
+      const transport: Transport = overrideUrl ? http(overrideUrl) : custom({ request: parentClient!.request });
 
       const burnerAccount = privateKeyToAccount(loadBurnerPK({ useSessionStorage }));
       const client = createWalletClient({
         chain: chain,
         account: burnerAccount,
-        transport: http(url),
+        transport,
       });
       const publicClient = createPublicClient({
         chain: chain,
-        transport: http(url),
+        transport,
       });
 
-      const request: EIP1193RequestFn = async ({ method, params }) => {
+      const request = (async ({ method, params }) => {
         if (method === "eth_sendTransaction") {
           const actualParams = (params as SendTransactionParameters[])[0];
           const hash = await client.sendTransaction({
@@ -281,13 +282,9 @@ export const burner = ({ useSessionStorage = false, rpcUrls = {} }: BurnerConfig
           return true;
         }
 
-        const body = { method, params };
-        const httpClient = getHttpRpcClient(url);
-        const { error, result } = await httpClient.request({ body });
-        if (error) throw new RpcRequestError({ body, error, url });
-
+        const result: unknown = await publicClient.request({ method, params } as never);
         return result;
-      };
+      }) as EIP1193RequestFn;
 
       return custom({ request })({ retryCount: 0 });
     },


### PR DESCRIPTION
> NOTE: This doesn't fix https://github.com/scaffold-eth/scaffold-eth-2/discussions/1265 specifically for SE-2 sinec our wagmi config has things configured via fallback route but if peole use a simple route using just `transport` to configure then it shall work.

## why

The cause is viem's `http()` with no URL falls through to `chain.rpcUrls.default.http[0]`. For mainnet that's `eth.merkle.io`, which blocks cross-origin requests from most live domains and rate-limits hard.

## what changed

New resolution order for the burner's RPC in `burner.ts`:

1. `rpcUrls[chainId]` passed to the burner. Same as before.
2. `config.transports[chainId]` from the consumer's wagmi config. Preserves fallback chains, Alchemy keys, anything else they configured. This is the same pattern the official `walletConnect` connector uses via `extractRpcUrls` in `@wagmi/core`.
3. A curated default for chains whose viem default is broken in production. Right now just `mainnet → mainnet.rpc.buidlguidl.com`. Easy to extend if other chains hit the same thing.
4. `chain.rpcUrls.default.http[0]`. Existing final fallback.

Also swapped the raw RPC passthrough from `getHttpRpcClient(url)` to `publicClient.request(...)` so it works with any transport shape, including the consumer's `fallback([...])` chain.

All additive, no breaking changes. Anyone already using `rpcUrls` keeps the exact same behavior.

## what this doesn't fix

Consumers using the `client({ chain })` factory form of `createConfig` (SE-2's current pattern) won't see their transport inherited. `config.transports` is undefined when the consumer uses `client()`, and the wagmi connector surface does not expose the client factory to connectors. Step 3 covers SE-2 on mainnet directly, so the reported CORS issue is resolved out of the box. For other chains those consumers would still need to set `rainbowkitBurnerWallet.rpcUrls` explicitly, or switch their wagmi config to the `transports: {}` form.

## test

The example app was updated to use `transports: {}` so inheritance is visible in the network tab. Connect with the burner, watch the RPC calls go to whatever Alchemy URL you configured at the wagmi level. No second RPC config needed on the wallet side.

## refs

- SE-2 discussion: https://github.com/scaffold-eth/scaffold-eth-2/discussions/1265
- wagmi `extractRpcUrls` (the pattern this mirrors): https://github.com/wevm/wagmi/blob/main/packages/core/src/utils/extractRpcUrls.ts
- walletConnect connector using it: https://github.com/wevm/wagmi/blob/main/packages/connectors/src/walletConnect.ts